### PR TITLE
Increase test timeout to 30 s in order to prevent test failures

### DIFF
--- a/test/test_io/test_io.c
+++ b/test/test_io/test_io.c
@@ -45,7 +45,7 @@
 #include <gutil_log.h>
 #include <gutil_macros.h>
 
-#define TEST_TIMEOUT (10) /* seconds */
+#define TEST_TIMEOUT (30) /* seconds */
 
 #define RIL_REQUEST_TEST_0 (10)
 #define RIL_REQUEST_TEST_1 (11)


### PR DESCRIPTION
This was causing build failures on our CI build servers.